### PR TITLE
Remove non-tagged elements from grouping results

### DIFF
--- a/app/formatters/SummaryHtml/Formatter.test.ts
+++ b/app/formatters/SummaryHtml/Formatter.test.ts
@@ -44,7 +44,7 @@ describe('format', () => {
         expect(await formatter.format(worklogSet)).toMatch('3hs');
     });
 
-    test('does not show tags if there are no aggregations (empty array)', async () => {
+    test('does not show tags when no aggregations are configured', async () => {
         const worklogSet = WorklogSets.singleNoTags();
         worklogSet.worklogs[0].startDateTime = Dates.pastTwoHours();
         worklogSet.worklogs[0].endDateTime = Dates.now();
@@ -57,35 +57,6 @@ describe('format', () => {
         expect(formatted).not.toMatch('client');
         expect(formatted).not.toMatch('project');
     });
-
-    test('does not show tags if there are no aggregations (null)', async () => {
-        const worklogSet = WorklogSets.singleNoTags();
-        worklogSet.worklogs[0].startDateTime = Dates.pastTwoHours();
-        worklogSet.worklogs[0].endDateTime = Dates.now();
-
-        const configuration = new SummaryHtmlFormatterConfiguration(null as any);
-        formatter = new SummaryHtmlFormatter(configuration, appConfiguration);
-
-        const formatted = await formatter.format(worklogSet);
-
-        expect(formatted).not.toMatch('client');
-        expect(formatted).not.toMatch('project');
-    });
-
-    test('does not show tags if there are no aggregations (undefined)', async () => {
-        const worklogSet = WorklogSets.singleNoTags();
-        worklogSet.worklogs[0].startDateTime = Dates.pastTwoHours();
-        worklogSet.worklogs[0].endDateTime = Dates.now();
-
-        const configuration = new SummaryHtmlFormatterConfiguration(undefined as any);
-        formatter = new SummaryHtmlFormatter(configuration, appConfiguration);
-
-        const formatted = await formatter.format(worklogSet);
-
-        expect(formatted).not.toMatch('client');
-        expect(formatted).not.toMatch('project');
-    });
-
 
     test('shows total by tag selection', async () => {
         const worklogSet = WorklogSets.singleNoTags();

--- a/app/formatters/SummaryHtml/Formatter.test.ts
+++ b/app/formatters/SummaryHtml/Formatter.test.ts
@@ -5,6 +5,7 @@ import { AppConfigurations, Dates, Tags, WorklogSets } from "../../../tests/enti
 import { Tag } from "../../models";
 import { IAppConfiguration } from "../../models/AppConfiguration";
 import { SummaryHtmlFormatter, SummaryHtmlFormatterConfiguration } from ".";
+import { WorklogSet } from "../../models/WorklogSet";
 
 describe('format', () => {
     let formatter: SummaryHtmlFormatter;
@@ -17,8 +18,8 @@ describe('format', () => {
     });
 
     test('rejects invalid worklogSets', async () => {
-        await expect(async () => await formatter.format(null)).rejects.toThrow('Missing WorklogSet.');
-        await expect(async () => await formatter.format(undefined)).rejects.toThrow('Missing WorklogSet.');
+        await expect(async () => await formatter.format(null as unknown as WorklogSet)).rejects.toThrow('Missing WorklogSet.');
+        await expect(async () => await formatter.format(undefined as unknown as WorklogSet)).rejects.toThrow('Missing WorklogSet.');
     });
 
     test('includes a header with dates', async () => {
@@ -62,7 +63,7 @@ describe('format', () => {
         worklogSet.worklogs[0].startDateTime = Dates.pastTwoHours();
         worklogSet.worklogs[0].endDateTime = Dates.now();
 
-        const configuration = new SummaryHtmlFormatterConfiguration(null);
+        const configuration = new SummaryHtmlFormatterConfiguration(null as any);
         formatter = new SummaryHtmlFormatter(configuration, appConfiguration);
 
         const formatted = await formatter.format(worklogSet);
@@ -76,7 +77,7 @@ describe('format', () => {
         worklogSet.worklogs[0].startDateTime = Dates.pastTwoHours();
         worklogSet.worklogs[0].endDateTime = Dates.now();
 
-        const configuration = new SummaryHtmlFormatterConfiguration(undefined);
+        const configuration = new SummaryHtmlFormatterConfiguration(undefined as any);
         formatter = new SummaryHtmlFormatter(configuration, appConfiguration);
 
         const formatted = await formatter.format(worklogSet);
@@ -98,10 +99,10 @@ describe('format', () => {
 
         const formatted = await formatter.format(worklogSet);
 
-        expect(formatted).toMatch('<p>Total time by client:</p>');
+        expect(formatted).toMatch('<p>Total time by client: (excluding non-tagged: 0hs 0m)</p>');
         expect(formatted).toMatch('<li>[client] ProCorp: 2hs 0m</li>');
 
-        expect(formatted).toMatch('<p>Total time by project:</p>');
+        expect(formatted).toMatch('<p>Total time by project: (excluding non-tagged: 0hs 0m)</p>');
         expect(formatted).toMatch('<li>[project] Project1: 2hs 0m</li>');
     });
 
@@ -121,7 +122,7 @@ describe('format', () => {
 
         const formatted = await formatter.format(worklogSet);
 
-        expect(formatted).toMatch('<p>Total time by client / project:</p>');
+        expect(formatted).toMatch('<p>Total time by client / project: (excluding non-tagged: 0hs 0m)</p>');
         expect(formatted).toMatch('<li>[client] ProCorp: 3hs 0m');
         expect(formatted).toMatch('<li>[project] Project1: 2hs 0m</li>');
         expect(formatted).toMatch('<li>[project] Project2: 1hs 0m</li>');

--- a/app/formatters/SummaryText/Formatter.test.ts
+++ b/app/formatters/SummaryText/Formatter.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, test, expect } from "@jest/globals";
 
 import { SummaryTextFormatter } from './Formatter';
-import { Worklog } from '../../models/Worklog';
 import { Tag } from '../../models/Tag';
 import { SummaryTextFormatterConfiguration } from './SummaryTextFormatterConfiguration';
 import { AppConfigurations, WorklogSets, Worklogs } from '../../../tests/entities';
+import { WorklogSet } from '../../models/WorklogSet';
 
 describe('SummaryTextFormatter', () => {
     let formatter: SummaryTextFormatter;
@@ -25,7 +25,7 @@ describe('SummaryTextFormatter', () => {
         });
 
         test('should throw error when worklogSet is invalid', async () => {
-            await expect(formatter.format(null as any)).rejects.toThrow('Missing WorklogSet.');
+            await expect(async () => await formatter.format(null as unknown as WorklogSet)).rejects.toThrow('Missing WorklogSet.');
         });
     });
 
@@ -130,17 +130,4 @@ describe('SummaryTextFormatter', () => {
             expect(result).toHaveLength(0);
         });
     });
-
-    // Helper functions to create mock worklogs
-    function createMockWorklog(description: string, startDateTime: Date, endDateTime: Date): Worklog {
-        return new Worklog(description, startDateTime, endDateTime);
-    }
-
-    function createMockWorklogWithTags(description: string, startDateTime: Date, endDateTime: Date, tags: Record<string, string>): Worklog {
-        const worklog = createMockWorklog(description, startDateTime, endDateTime);
-        Object.entries(tags).forEach(([key, value]) => {
-            worklog.addTag(new Tag(key, value));
-        });
-        return worklog;
-    }
 }); 

--- a/app/formatters/SummaryText/Formatter.test.ts
+++ b/app/formatters/SummaryText/Formatter.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, test, expect } from "@jest/globals";
+
+import { SummaryTextFormatter } from './Formatter';
+import { Worklog } from '../../models/Worklog';
+import { Tag } from '../../models/Tag';
+import { SummaryTextFormatterConfiguration } from './SummaryTextFormatterConfiguration';
+import { AppConfigurations, WorklogSets, Worklogs } from '../../../tests/entities';
+
+describe('SummaryTextFormatter', () => {
+    let formatter: SummaryTextFormatter;
+    const mockConfig = new SummaryTextFormatterConfiguration([['project'], ['type']]);
+
+    beforeEach(() => {
+        formatter = new SummaryTextFormatter(mockConfig, AppConfigurations.normal());
+    });
+
+    describe('format', () => {
+        test('should format worklog set with correct date range and total time', async () => {
+            const worklogSet = WorklogSets.double();
+
+            const result = await formatter.format(worklogSet);
+            
+            expect(result).toContain('Worklogs from');
+            expect(result).toContain('Total time:');
+        });
+
+        test('should throw error when worklogSet is invalid', async () => {
+            await expect(formatter.format(null as any)).rejects.toThrow('Missing WorklogSet.');
+        });
+    });
+
+    describe('_getWorklogDurationSumInMinutes', () => {
+        test('should correctly sum durations of multiple worklogs', () => {
+            const worklogs = [
+                Worklogs.normal(),
+                Worklogs.normal2(),
+                Worklogs.noDuration()
+            ];
+
+            const result = formatter._getWorklogDurationSumInMinutes(worklogs);
+            expect(result).toBeGreaterThan(0);
+        });
+
+        test('should return 0 for empty worklog array', () => {
+            const result = formatter._getWorklogDurationSumInMinutes([]);
+            expect(result).toBe(0);
+        });
+    });
+
+    describe('_getTotalHsMsString', () => {
+        test('should format hours and minutes correctly', () => {
+            expect(formatter._getTotalHsMsString(90)).toBe('1hs 30m');
+            expect(formatter._getTotalHsMsString(45)).toBe('0hs 45m');
+            expect(formatter._getTotalHsMsString(150)).toBe('2hs 30m');
+        });
+    });
+
+    describe('_generateAggregations', () => {
+        test('should generate correct aggregations based on tags', () => {
+            const worklogSet = WorklogSets.double();
+            worklogSet.worklogs.forEach(w => {
+                w.addTag(new Tag('type', 'Development'));
+            });
+
+            const result = formatter._generateAggregations(worklogSet);
+            expect(result).toHaveLength(2); // Two aggregation groups
+            expect(result[0][0]).toBe('Total time by project: (excluding non-tagged: 0hs 0m)');
+            expect(result[1][0]).toBe('Total time by type: (excluding non-tagged: 0hs 0m)');
+        });
+
+        test('should exclude worklogs without the specified tag from summarization and show them in non-tagged time', () => {
+            const worklogSet = WorklogSets.mixed();
+            worklogSet.worklogs[0].addTag(new Tag('project', 'Project A')); // Only project tag
+            worklogSet.worklogs[1].addTag(new Tag('type', 'Testing')); // Only type tag
+            worklogSet.worklogs[2].addTag(new Tag('project', 'Project B')); // Only project tag
+            worklogSet.worklogs[2].addTag(new Tag('type', 'Development')); // And type tag
+
+            const result = formatter._generateAggregations(worklogSet);
+            
+            // Project aggregation should show worklogs[1] as non-tagged
+            const projectAggregation = result[0].join('\n');
+            expect(projectAggregation).toContain('Project A:');
+            expect(projectAggregation).toContain('Project B:');
+            expect(projectAggregation).toMatch(/Total time by project: \(excluding non-tagged: \d+hs \d+m\)/);
+            
+            // Type aggregation should show worklogs[0] and part of worklogs[2] as non-tagged
+            const typeAggregation = result[1].join('\n');
+            expect(typeAggregation).toContain('Testing:');
+            expect(typeAggregation).toContain('Development:');
+            expect(typeAggregation).toMatch(/Total time by type: \(excluding non-tagged: \d+hs \d+m\)/);
+        });
+
+        test('should include worklogs in multiple tag summarizations and track non-tagged time separately', () => {
+            formatter = new SummaryTextFormatter(new SummaryTextFormatterConfiguration([['project'], ['type'], ['priority']]), AppConfigurations.normal());
+            
+            const worklogSet = WorklogSets.double();
+            // First worklog has all tags
+            worklogSet.worklogs[0].addTag(new Tag('project', 'Project A'));
+            worklogSet.worklogs[0].addTag(new Tag('type', 'Development'));
+            worklogSet.worklogs[0].addTag(new Tag('priority', 'High'));
+            // Second worklog has only project and priority
+            worklogSet.worklogs[1].addTag(new Tag('project', 'Project A'));
+            worklogSet.worklogs[1].addTag(new Tag('priority', 'Low'));
+
+            const result = formatter._generateAggregations(worklogSet);
+            expect(result).toHaveLength(3); // Three aggregation groups
+
+            // Project aggregation should have no non-tagged time
+            const projectAggregation = result[0].join('\n');
+            expect(projectAggregation).toContain('Project A:');
+            expect(projectAggregation).toContain('(excluding non-tagged: 0hs 0m)');
+
+            // Type aggregation should show second worklog as non-tagged
+            const typeAggregation = result[1].join('\n');
+            expect(typeAggregation).toContain('Development:');
+            expect(typeAggregation).toMatch(/Total time by type: \(excluding non-tagged: \d+hs \d+m\)/);
+
+            // Priority aggregation should have no non-tagged time
+            const priorityAggregation = result[2].join('\n');
+            expect(priorityAggregation).toContain('High:');
+            expect(priorityAggregation).toContain('Low:');
+            expect(priorityAggregation).toContain('(excluding non-tagged: 0hs 0m)');
+        });
+
+        test('should return empty array when no aggregation tags configured', () => {
+            const worklogSet = WorklogSets.empty();
+            formatter = new SummaryTextFormatter(new SummaryTextFormatterConfiguration([]), AppConfigurations.normal());
+
+            const result = formatter._generateAggregations(worklogSet);
+            expect(result).toHaveLength(0);
+        });
+    });
+
+    // Helper functions to create mock worklogs
+    function createMockWorklog(description: string, startDateTime: Date, endDateTime: Date): Worklog {
+        return new Worklog(description, startDateTime, endDateTime);
+    }
+
+    function createMockWorklogWithTags(description: string, startDateTime: Date, endDateTime: Date, tags: Record<string, string>): Worklog {
+        const worklog = createMockWorklog(description, startDateTime, endDateTime);
+        Object.entries(tags).forEach(([key, value]) => {
+            worklog.addTag(new Tag(key, value));
+        });
+        return worklog;
+    }
+}); 


### PR DESCRIPTION
Fixes #2061
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Exclude non-tagged worklogs from aggregations and track their time separately in summary formatters.
> 
>   - **Behavior**:
>     - Excludes non-tagged worklogs from aggregations in `SummaryTextFormatter` and `SummaryHtmlFormatter`.
>     - Tracks non-tagged time separately and displays it in the summary output.
>   - **Tests**:
>     - Updates `Formatter.test.ts` to remove redundant tests for null and undefined aggregations.
>     - Adds `Formatter.test.ts` for `SummaryTextFormatter` to test non-tagged time handling and aggregation logic.
>   - **Functions**:
>     - Modifies `_generateAggregations()` in `SummaryText/Formatter.ts` to filter non-tagged worklogs and calculate their duration separately.
>     - Updates `_generateAggregationLines()` to skip entries with no key value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AlphaGit%2Fworklogger&utm_source=github&utm_medium=referral)<sup> for ffddd7e18ba70f7939caca03946aae1e9384bc64. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->