### PR TITLE
Fix outputted typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The particular objective of this system is to allow me to automate my timesheet 
 
 ## Application data flow
 
-1. **Inputs** read worklogs from different data sources. Each worklog represents a particular instance of work to be outputed somewhere. After reading the input from all the sources, they all get added into a WorklogSet instance.
+1. **Inputs** read worklogs from different data sources. Each worklog represents a particular instance of work to be outputted somewhere. After reading the input from all the sources, they all get added into a WorklogSet instance.
 1. **WorklogSetOperations** allow to transform that end-result of worklog set. For example, operations like adding new worklogs or merging different worklogs together would work here. The worklog set gets modified to leave a new set of worklogs.
 1. Transformation **actions** operate on each particular worklog, by reading and modifying data on it. Most of the modifications will be done over a tagging system: every worklog has tags that will determine if it goes through any particular flow. These transformations will create more tags to them.
     1. **Conditions** will filter worklogs from reaching a particular action.


### PR DESCRIPTION
## Summary
- fix a typo in `README.md`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_684779411cb4832b9e16296d1f1a5da8
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `README.md`, changing 'outputed' to 'outputted'.
> 
>   - **Documentation**:
>     - Fix typo in `README.md`, changing 'outputed' to 'outputted'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AlphaGit%2Fworklogger&utm_source=github&utm_medium=referral)<sup> for 5643cee2ebe0b83537c5f50741b0beea9bfebc81. You can [customize](https://app.ellipsis.dev/AlphaGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->