### PR TITLE
Fix header typo in docs

### DIFF
--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,4 +1,4 @@
-## Logger categoroies
+## Logger categories
 
 The categories used for the logger should be one of:
 


### PR DESCRIPTION
## Summary
- fix typo in docs/design-decisions

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68477b2400ac832bb17e85255eaf8935