### PR TITLE
Add tests for unknown output and formatter types

### DIFF
--- a/app/services/outputLoader.test.ts
+++ b/app/services/outputLoader.test.ts
@@ -72,4 +72,38 @@ describe('loadOutputs', () => {
         expect(output3.output).toBeInstanceOf(JiraWorklogOutput);
         expect(output3.output.formatter).toBeInstanceOf(NoFormatFormatter);
     });
+
+    test('rejects if output type is not recognized', async () => {
+        const outputConfigs = [{
+            type: 'UnknownOutput',
+            name: 'output1',
+            excludeFromNonProcessedWarning: false,
+            condition: {
+                type: ''
+            },
+            formatter: {
+                type: ''
+            }
+        }];
+
+        await expect(async () => await loadOutputs(outputConfigs, appConfiguration))
+            .rejects.toThrow('Output UnknownOutput not recognized.');
+    });
+
+    test('rejects if formatter type is not recognized', async () => {
+        const outputConfigs = [{
+            type: 'Logger',
+            name: 'output1',
+            excludeFromNonProcessedWarning: false,
+            condition: {
+                type: ''
+            },
+            formatter: {
+                type: 'UnknownFormatter'
+            }
+        }];
+
+        await expect(async () => await loadOutputs(outputConfigs, appConfiguration))
+            .rejects.toThrow('Formatter UnknownFormatter not recognized.');
+    });
 });


### PR DESCRIPTION
## Summary
- cover error cases for loading unknown outputs or formatters

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68477b30697c832b910c809383b273e0