### PR TITLE
chore: remove deprecated ts-jest isolatedModules option

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
       "^.+\\.tsx?$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.json",
-          "isolatedModules": true
+          "tsconfig": "tsconfig.json"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- avoid ts-jest deprecation warning by removing isolatedModules option

## Testing
- `yarn test:all`


------
https://chatgpt.com/codex/tasks/task_b_688f7b90d280832bafb3ea49f60708ac
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `isolatedModules` option from `ts-jest` configuration in `package.json`.
> 
>   - **Configuration**:
>     - Remove `isolatedModules` option from `ts-jest` configuration in `package.json` to avoid deprecation warning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AlphaGit%2Fworklogger&utm_source=github&utm_medium=referral)<sup> for dbcf979e7e6ae67f5cdf78e9e878e4c468b3f118. You can [customize](https://app.ellipsis.dev/AlphaGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->