### PR TITLE
fix: overwrite existing tag values

### DIFF
--- a/app/actions/AddTag/AddTagAction.test.ts
+++ b/app/actions/AddTag/AddTagAction.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, test, expect } from "@jest/globals";
 
-import { Worklogs } from "../../../tests/entities";
-import { AddTagAction } from "./AddTagAction";
-import { AddTagConfiguration } from "./AddTagConfiguration";
-import { AddTagDefinition } from "./AddTagDefinition";
+import { Worklogs } from '../../../tests/entities';
+import { AddTagAction } from './AddTagAction';
+import { AddTagConfiguration } from './AddTagConfiguration';
+import { AddTagDefinition } from './AddTagDefinition';
+import { Tag } from '../../models';
 
 let addTagDefinition: AddTagDefinition;
 let addTagConfiguration: AddTagConfiguration;
@@ -75,6 +76,14 @@ describe('apply', () => {
 
             expect(worklog.getTagValue('tagName')).toBe('');
         });
+    });
+
+    test('overwrites existing tag value', () => {
+        const worklog = Worklogs.noTags();
+        worklog.addTag(new Tag(addTagDefinition.name, 'oldValue'));
+        addTagAction.apply(worklog);
+        const { name, value } = addTagDefinition;
+        expect(worklog.getTagValue(name)).toBe(value);
     });
 
     test('reject invalid worklogs', () => {

--- a/app/models/Worklog.test.ts
+++ b/app/models/Worklog.test.ts
@@ -117,6 +117,15 @@ describe('addTag', () => {
         worklog.addTag(new Tag('tag1', 'value1'));
         expect(worklog.getTagKeys()).toContain('tag1');
     });
+
+    test('overwrites existing tag value when adding the same tag again', () => {
+        const worklog = Worklogs.noTags();
+
+        worklog.addTag(new Tag('tag1', 'value1'));
+        worklog.addTag(new Tag('tag1', 'value2'));
+
+        expect(worklog.getTagValue('tag1')).toBe('value2');
+    });
 });
 
 describe('getTagKeys', () => {


### PR DESCRIPTION
## Summary
- overwrite existing tags in Worklog.addTag
- remove explicit tag removal in AddTagAction
- add tests ensuring tags are overwritten

## Testing
- `yarn test:all`


------
https://chatgpt.com/codex/tasks/task_b_68b5ae72b620832ba535c43e11aef582